### PR TITLE
fix: get 'profile' only from header for PatchCustomerProfileKeyResolv…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ xm_commons_version=2.1.16
 lombok_version=1.18.2
 
 # jhipster-needle-gradle-property - JHipster will add additional properties here
-version=2.0.11
+version=2.0.12
 ## below are some of the gradle performance improvement settings that can be used as required, these are not enabled by default
 
 ## The Gradle daemon aims to improve the startup and execution time of Gradle.

--- a/src/main/java/com/icthh/xm/tmf/ms/customer/lep/keyresolver/PatchCustomerProfileKeyResolver.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/customer/lep/keyresolver/PatchCustomerProfileKeyResolver.java
@@ -1,12 +1,17 @@
 package com.icthh.xm.tmf.ms.customer.lep.keyresolver;
 
+import static java.util.Optional.ofNullable;
+
 import com.icthh.xm.lep.api.LepKey;
 import com.icthh.xm.lep.api.LepKeyResolver;
 import com.icthh.xm.lep.api.LepManagerService;
 import com.icthh.xm.lep.api.LepMethod;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 
 /**
@@ -23,7 +28,11 @@ public class PatchCustomerProfileKeyResolver implements LepKeyResolver {
 
     @Override
     public LepKey resolve(LepKey baseKey, LepMethod method, LepManagerService managerService) {
-        if (!StringUtils.isBlank(profileKeyResolver.getProfile(method))) {
+        HttpServletRequest request =
+                ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+        String profile = ofNullable(request.getHeader("Profile"))
+                .orElseGet(String::new);
+        if (!StringUtils.isBlank(profile)) {
             return profileKeyResolver.resolve(baseKey, method, managerService);
         }
         return baseKey;

--- a/src/main/java/com/icthh/xm/tmf/ms/customer/lep/keyresolver/ProfileKeyResolver.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/customer/lep/keyresolver/ProfileKeyResolver.java
@@ -27,7 +27,7 @@ public class ProfileKeyResolver extends AppendLepKeyResolver {
         return new String[]{translated};
     }
 
-    String getProfile(LepMethod method) {
+    private String getProfile(LepMethod method) {
         HttpServletRequest request =
             ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
         return ofNullable(request.getHeader("Profile"))


### PR DESCRIPTION
fix: get 'profile' only from header for PatchCustomerProfileKeyResolver.java instead of header OR method param