### PR TITLE
added profile aware http metrics

### DIFF
--- a/.github/workflows/autoincrement-project-version.yml
+++ b/.github/workflows/autoincrement-project-version.yml
@@ -2,7 +2,7 @@
 # For more information see: https://github.com/actions/setup-java#publishing-using-gradle
 
 name: Autoincrement project version
-on: 
+on:
   pull_request:
     types: [opened,labeled,unlabeled]
     branches:
@@ -21,7 +21,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 8
+        java-version: 17
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
@@ -33,7 +33,7 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         if [ "$event" == "opened" ] || ([ "$event" == "unlabeled" ] && [ "$event_label_name" == "do_not_increment_version" ])
-        then 
+        then
           ./gradlew incrementProjectVersion --no-daemon
         git commit -m "autoincrement project version" -a || echo "no changes"
         elif [ "$event" == "labeled" ] && [ "$event_label_name" == "do_not_increment_version" ]

--- a/src/main/java/com/icthh/xm/tmf/ms/customer/config/ProfileAwareRestTemplateExchangeTagsProvider.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/customer/config/ProfileAwareRestTemplateExchangeTagsProvider.java
@@ -1,0 +1,26 @@
+package com.icthh.xm.tmf.ms.customer.config;
+
+import io.micrometer.core.instrument.Tag;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTags;
+import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+
+public class ProfileAwareRestTemplateExchangeTagsProvider implements RestTemplateExchangeTagsProvider {
+
+    @Override
+    public Iterable<Tag> getTags(String urlTemplate, HttpRequest request, ClientHttpResponse response) {
+        String profileValue = Optional.of(request.getHeaders())
+            .map(headers -> headers.get("Profile"))
+            .orElse(Collections.emptyList())
+            .stream()
+            .findFirst()
+            .orElse("none");
+        return Arrays.asList(RestTemplateExchangeTags.method(request), Tag.of("profile", profileValue),
+            RestTemplateExchangeTags.status(response), RestTemplateExchangeTags.clientName(request));
+    }
+
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/customer/config/RestTemplateConfiguration.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/customer/config/RestTemplateConfiguration.java
@@ -3,6 +3,7 @@ package com.icthh.xm.tmf.ms.customer.config;
 import com.icthh.xm.tmf.ms.customer.config.ApplicationProperties.CustomerTimeoutProperties;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.metrics.web.client.RestTemplateExchangeTagsProvider;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -31,6 +32,16 @@ public class RestTemplateConfiguration {
 
         customizer.customize(restTemplate);
         return restTemplate;
+    }
+
+    @ConditionalOnProperty(
+        value = {"http.metrics.profile.aware"},
+        havingValue = "true"
+    )
+    @Bean
+    public RestTemplateExchangeTagsProvider tagProvider() {
+        log.info("creating profileAware metrics tag provider");
+        return new ProfileAwareRestTemplateExchangeTagsProvider();
     }
 
     @Bean("customerRestTemplate")


### PR DESCRIPTION
The existing DefaultRestTemplateExchangeTagsProvider, used by the MetricsInterceptor, adds the uri as a label for each request metric. We faced a case where there are a lot of different non unique uris, and this leads to Prometheus overload. Was decided to add profile as a lable instead of the uri, as in our case profile value is used for endpoint definition