### PR TITLE
BS1-10008: add security-masking logging appender for customer service

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=tmf-ms-customer
 profile=dev
-version=0.0.4
+version=0.0.5
 
 # Dependency versions
 jhipsterDependenciesVersion=7.9.3

--- a/src/main/java/com/icthh/xm/tmf/ms/customer/aop/logging/MaskedLoggingEvent.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/customer/aop/logging/MaskedLoggingEvent.java
@@ -1,0 +1,94 @@
+package com.icthh.xm.tmf.ms.customer.aop.logging;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import java.util.Map;
+import org.slf4j.Marker;
+
+public class MaskedLoggingEvent implements ILoggingEvent {
+
+    private final ILoggingEvent delegate;
+    private final String maskedMessage;
+
+    public MaskedLoggingEvent(ILoggingEvent delegate, String maskedMessage) {
+        this.delegate = delegate;
+        this.maskedMessage = maskedMessage;
+    }
+
+    @Override
+    public String getThreadName() {
+        return delegate.getThreadName();
+    }
+
+    @Override
+    public Level getLevel() {
+        return delegate.getLevel();
+    }
+
+    @Override
+    public String getMessage() {
+        return maskedMessage;
+    }
+
+    @Override
+    public Object[] getArgumentArray() {
+        return null;
+    }
+
+    @Override
+    public String getFormattedMessage() {
+        return maskedMessage;
+    }
+
+    @Override
+    public String getLoggerName() {
+        return delegate.getLoggerName();
+    }
+
+    @Override
+    public LoggerContextVO getLoggerContextVO() {
+        return delegate.getLoggerContextVO();
+    }
+
+    @Override
+    public IThrowableProxy getThrowableProxy() {
+        return delegate.getThrowableProxy();
+    }
+
+    @Override
+    public StackTraceElement[] getCallerData() {
+        return delegate.getCallerData();
+    }
+
+    @Override
+    public boolean hasCallerData() {
+        return delegate.hasCallerData();
+    }
+
+    @Override
+    public Marker getMarker() {
+        return delegate.getMarker();
+    }
+
+    @Override
+    public Map<String, String> getMDCPropertyMap() {
+        return delegate.getMDCPropertyMap();
+    }
+
+    @Override
+    public Map<String, String> getMdc() {
+        return delegate.getMdc();
+    }
+
+    @Override
+    public long getTimeStamp() {
+        return delegate.getTimeStamp();
+    }
+
+    @Override
+    public void prepareForDeferredProcessing() {
+        delegate.prepareForDeferredProcessing();
+    }
+}

--- a/src/main/java/com/icthh/xm/tmf/ms/customer/aop/logging/SecurityMaskingConsoleAppender.java
+++ b/src/main/java/com/icthh/xm/tmf/ms/customer/aop/logging/SecurityMaskingConsoleAppender.java
@@ -1,0 +1,60 @@
+package com.icthh.xm.tmf.ms.customer.aop.logging;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.ConsoleAppender;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SecurityMaskingConsoleAppender extends ConsoleAppender<ILoggingEvent> {
+
+    private final List<String> keywords = new ArrayList<>();
+    private String replacementMessage;
+
+    public void addKeyword(String keyword) {
+        if (keyword != null && !keyword.isBlank()) {
+            keywords.add(keyword);
+        }
+    }
+
+    public void setKeywords(String keywords) {
+        if (keywords == null || keywords.isBlank()) return;
+
+        for (String k : keywords.split(",")) {
+            addKeyword(k.trim());
+        }
+    }
+
+    public void setReplacementMessage(String replacementMessage) {
+        if (replacementMessage != null && !replacementMessage.isBlank()) {
+            this.replacementMessage = replacementMessage;
+        }
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        ILoggingEvent toLog = eventObject;
+
+        String msg = eventObject.getFormattedMessage();
+        if (msg == null) {
+            msg = eventObject.getMessage();
+        }
+
+        if (msg != null && containsSensitive(msg)) {
+            toLog = new MaskedLoggingEvent(eventObject, replacementMessage);
+        }
+
+        super.append(toLog);
+    }
+
+    private boolean containsSensitive(String msg) {
+        if (keywords.isEmpty()) {
+            return false;
+        }
+        for (String keyword : keywords) {
+            if (msg.contains(keyword)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,15 +5,23 @@
 
     <springProperty scope="context" name="springAppName" source="spring.application.name"/>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="STDOUT"
+              class="com.icthh.xm.tmf.ms.customer.aop.logging.SecurityMaskingConsoleAppender">
         <encoder>
             <charset>utf-8</charset>
             <Pattern>%d %-5level [%thread] [${springAppName:-}] [%X{traceId:-}] [%X{rid}] %logger{0}: %msg%n</Pattern>
         </encoder>
+
+        <keywords>${LOGBACK_SECURITY_MASKING_KEYWORDS: }</keywords>
+        <replacementMessage>${LOGBACK_SECURITY_MASKING_REPLACEMENT_MESSAGE:this log was removed due to potential security breach}</replacementMessage>
     </appender>
 
-    <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="STDOUT_JSON"
+              class="com.icthh.xm.tmf.ms.customer.aop.logging.SecurityMaskingConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+
+        <keywords>${LOGBACK_SECURITY_MASKING_KEYWORDS: }</keywords>
+        <replacementMessage>${LOGBACK_SECURITY_MASKING_REPLACEMENT_MESSAGE:this log was removed due to potential security breach}</replacementMessage>
     </appender>
 
     <logger name="com.icthh.xm.ms.entity" level="#logback.loglevel#"/>

--- a/src/test/java/com/icthh/xm/tmf/ms/customer/aop/logging/SecurityMaskingConsoleAppenderTest.java
+++ b/src/test/java/com/icthh/xm/tmf/ms/customer/aop/logging/SecurityMaskingConsoleAppenderTest.java
@@ -1,0 +1,151 @@
+package com.icthh.xm.tmf.ms.customer.aop.logging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import net.logstash.logback.encoder.LogstashEncoder;
+import org.junit.jupiter.api.Test;
+
+class SecurityMaskingConsoleAppenderTest {
+
+    @Test
+    void shouldReplaceMessageForPatternEncoderWhenContainsKeyword() {
+        LoggerContext context = new LoggerContext();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(out));
+
+        try {
+            // encoder
+            PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+            encoder.setContext(context);
+            encoder.setPattern("%msg%n");
+            encoder.start();
+
+            // appender
+            SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+            appender.setContext(context);
+            appender.setEncoder(encoder);
+            appender.setKeywords("keyword:, keyword=");
+            appender.setReplacementMessage("this log was removed due to potential security breach");
+            appender.start();
+
+            // logger
+            Logger logger = context.getLogger("test.pattern.logger");
+            logger.detachAndStopAllAppenders();
+            logger.setLevel(Level.INFO);
+            logger.setAdditive(false);
+            logger.addAppender(appender);
+
+            // when
+            logger.info("safe message");
+            logger.info("keyword: 1234");
+
+            System.out.flush();
+
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        String output = out.toString();
+        String[] lines = output.split("\\R");
+
+        assertThat(lines).hasSize(2);
+        assertThat(lines[0]).isEqualTo("safe message");
+        assertThat(lines[1]).isEqualTo("this log was removed due to potential security breach");
+    }
+
+    @Test
+    void shouldReplaceMessageForJsonEncoderWhenContainsKeyword() {
+        LoggerContext context = new LoggerContext();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(out));
+
+        try {
+            // JSON encoder
+            LogstashEncoder encoder = new LogstashEncoder();
+            encoder.setContext(context);
+            encoder.start();
+
+            SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+            appender.setContext(context);
+            appender.setEncoder(encoder);
+            appender.setKeywords("keyword:, keyword=");
+            appender.setReplacementMessage("this log was removed due to potential security breach");
+            appender.start();
+
+            Logger logger = context.getLogger("test.json.logger");
+            logger.detachAndStopAllAppenders();
+            logger.setLevel(Level.INFO);
+            logger.setAdditive(false);
+            logger.addAppender(appender);
+
+            // when
+            logger.info("safe json");
+            logger.info("keyword=qwerty");
+
+            System.out.flush();
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        String output = out.toString();
+        String[] lines = output.split("\\R");
+
+        assertThat(lines.length).isGreaterThanOrEqualTo(2);
+
+        String first = lines[0];
+        String second = lines[1];
+
+        assertThat(first).contains("safe json");
+        assertThat(first).doesNotContain("this log was removed due to potential security breach");
+
+        assertThat(second).contains("this log was removed due to potential security breach");
+        assertThat(second).doesNotContain("keyword=qwerty");
+    }
+
+    @Test
+    void shouldNotMaskWhenNoKeywordsConfigured() {
+        LoggerContext context = new LoggerContext();
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        System.setOut(new PrintStream(out));
+
+        try {
+            PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+            encoder.setContext(context);
+            encoder.setPattern("%msg%n");
+            encoder.start();
+
+            SecurityMaskingConsoleAppender appender = new SecurityMaskingConsoleAppender();
+            appender.setContext(context);
+            appender.setEncoder(encoder);
+            appender.start();
+
+            Logger logger = context.getLogger("test.no.keyword");
+            logger.detachAndStopAllAppenders();
+            logger.setLevel(Level.INFO);
+            logger.setAdditive(false);
+            logger.addAppender(appender);
+
+            logger.info("keyword: should stay as is");
+
+            System.out.flush();
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        String output = out.toString().trim();
+
+        assertThat(output).isEqualTo("keyword: should stay as is");
+    }
+}


### PR DESCRIPTION
**Summary:**
Introduce a security-aware console appender to mask sensitive values in logs for `customer` flows.
Update logging config to use `com.icthh.xm.tmf.ms.customer.aop.logging.SecurityMaskingConsoleAppender` for both plain and `JSON` console output.

**Changes:**
Modified `src/main/customer/logback-spring.xml`:
Replaced default console appenders with `SecurityMaskingConsoleAppender` for `STDOUT` and `STDOUT_JSON`.
`STDOUT_JSON` uses `net.logstash.logback.encoder.LogstashEncoder`.
Added appender properties with environment fallbacks:
`LOGBACK_SECURITY_MASKING_KEYWORDS` — comma-separated keywords to mask.
`LOGBACK_SECURITY_MASKING_REPLACEMENT_MESSAGE` — replacement text (default: this log was removed due to potential security breach).

**Why:**
Prevent accidental leakage of sensitive data in application logs by masking configured keywords before output.

Configuration / Usage:
Set `LOGBACK_SECURITY_MASKING_KEYWORDS` (e.g. password,token,ssn) and optionally `LOGBACK_SECURITY_MASKING_REPLACEMENT_MESSAGE`.
Default appender selected via `LOG_APPENDER_NAME` (defaults to `STDOUT`).

### **!!! Important:**
`**LOGBACK_SECURITY_MASKING_KEYWORDS**` is empty by default.
This means the SecurityMaskingConsoleAppender will run in no-op mode unless the keywords are configured (e.g. password,token).
Masking becomes active only after explicit configuration.